### PR TITLE
feat: add BCF API routes

### DIFF
--- a/backend/app/api/routes_bcf.py
+++ b/backend/app/api/routes_bcf.py
@@ -1,0 +1,80 @@
+"""FastAPI routes related to BCF operations."""
+from __future__ import annotations
+
+import os
+import tempfile
+
+from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi.responses import FileResponse
+from starlette.background import BackgroundTask
+
+from app.bcf import merger, reader
+
+router = APIRouter(prefix="/bcf", tags=["bcf"])
+
+
+async def _save_upload_to_temp(upload: UploadFile) -> str:
+    suffix = os.path.splitext(upload.filename or "")[1] or ".bcfzip"
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        await upload.seek(0)
+        contents = await upload.read()
+        tmp.write(contents)
+        return tmp.name
+
+
+def _cleanup_file(path: str) -> None:
+    if path and os.path.exists(path):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
+@router.post("/inspect")
+async def inspect_bcf(file: UploadFile = File(...)) -> dict:
+    if file is None:
+        raise HTTPException(status_code=400, detail="Aucun fichier fourni.")
+
+    temp_path = ""
+    try:
+        temp_path = await _save_upload_to_temp(file)
+        project_meta, topics = reader.read_bcf(temp_path)
+    except Exception as exc:  # pragma: no cover - defensive programming
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    finally:
+        _cleanup_file(temp_path)
+        await file.close()
+
+    return {"project": project_meta, "topics": topics}
+
+
+@router.post("/merge")
+async def merge_bcfs(files: list[UploadFile] = File(...)) -> FileResponse:
+    if not files:
+        raise HTTPException(status_code=400, detail="Aucun fichier fourni.")
+
+    temp_paths: list[str] = []
+    merged_path = ""
+    try:
+        for upload in files:
+            temp_paths.append(await _save_upload_to_temp(upload))
+
+        merged_path = merger.merge_bcfs(temp_paths)
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive programming
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    finally:
+        for upload in files:
+            await upload.close()
+        for path in temp_paths:
+            if path != merged_path:
+                _cleanup_file(path)
+
+    background = BackgroundTask(_cleanup_file, merged_path)
+    return FileResponse(
+        merged_path,
+        filename="merged.bcfzip",
+        media_type="application/octet-stream",
+        background=background,
+    )

--- a/backend/app/bcf/merger.py
+++ b/backend/app/bcf/merger.py
@@ -1,0 +1,68 @@
+"""Utilities for merging multiple BCF archives."""
+from __future__ import annotations
+
+import tempfile
+import zipfile
+from typing import Iterable
+
+
+def _increment_component(name: str, counter: int) -> str:
+    if "." in name:
+        stem, ext = name.rsplit(".", 1)
+        return f"{stem}_{counter}.{ext}"
+    return f"{name}_{counter}"
+
+
+def _increment_path(path: str, counter: int) -> str:
+    if path.endswith("/"):
+        base = path.rstrip("/")
+        incremented = _increment_path(base, counter)
+        return f"{incremented}/"
+    if "/" in path:
+        parent, name = path.rsplit("/", 1)
+        return f"{parent}/{_increment_component(name, counter)}"
+    return _increment_component(path, counter)
+
+
+def merge_bcfs(bcf_paths: Iterable[str]) -> str:
+    """Merge multiple BCF archives into a single temporary archive."""
+    paths: list[str] = [path for path in bcf_paths if path]
+    if not paths:
+        raise ValueError("No BCF archives provided for merging.")
+
+    merged_file = tempfile.NamedTemporaryFile(delete=False, suffix=".bcfzip")
+    merged_file.close()
+
+    existing_names: set[str] = set()
+
+    with zipfile.ZipFile(merged_file.name, "w", compression=zipfile.ZIP_DEFLATED) as output_zip:
+        for path in paths:
+            with zipfile.ZipFile(path, "r") as input_zip:
+                for info in input_zip.infolist():
+                    name = info.filename
+                    candidate = name
+                    counter = 1
+                    while candidate in existing_names:
+                        candidate = _increment_path(name, counter)
+                        counter += 1
+
+                    info_copy = zipfile.ZipInfo(filename=candidate, date_time=info.date_time)
+                    info_copy.comment = info.comment
+                    info_copy.compress_type = info.compress_type
+                    info_copy.create_system = info.create_system
+                    info_copy.create_version = info.create_version
+                    info_copy.extract_version = info.extract_version
+                    info_copy.external_attr = info.external_attr
+                    info_copy.flag_bits = info.flag_bits
+                    info_copy.internal_attr = info.internal_attr
+                    info_copy.extra = info.extra
+                    info_copy.volume = info.volume
+
+                    data = b""
+                    if not info.is_dir():
+                        data = input_zip.read(info.filename)
+
+                    output_zip.writestr(info_copy, data)
+                    existing_names.add(candidate)
+
+    return merged_file.name

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,20 +1,13 @@
-from fastapi import FastAPI, UploadFile
-from fastapi.responses import JSONResponse, FileResponse
-import tempfile
+from fastapi import FastAPI
+
+from app.api.routes_bcf import router as bcf_router
 
 app = FastAPI()
+
 
 @app.get("/healthz")
 def health():
     return {"status": "ok"}
 
-@app.post("/bcf/inspect")
-async def inspect(file: UploadFile):
-    # TODO: utiliser reader.py pour extraire les issues
-    return JSONResponse({"project": {}, "topics": []})
 
-@app.post("/bcf/merge")
-async def merge(files: list[UploadFile]):
-    # TODO: utiliser merger.py + writer.py
-    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".bcfzip")
-    return FileResponse(tmp.name, filename="merged.bcfzip")
+app.include_router(bcf_router)


### PR DESCRIPTION
## Summary
- add a FastAPI router that exposes BCF inspection and merge endpoints
- wire the new router into the application entrypoint
- implement a utility for merging multiple BCF archives

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68dd3f608200832695fbf050c9b88169