### PR TITLE
Align frontend and backend BCF integration

### DIFF
--- a/backend/app/api/routes_bcf.py
+++ b/backend/app/api/routes_bcf.py
@@ -1,8 +1,10 @@
 """FastAPI routes related to BCF operations."""
 from __future__ import annotations
 
+import base64
 import os
 import tempfile
+from typing import Any, Dict
 
 from fastapi import APIRouter, File, HTTPException, UploadFile
 from fastapi.responses import FileResponse
@@ -30,22 +32,91 @@ def _cleanup_file(path: str) -> None:
             pass
 
 
+def _serialise_snapshot(topic: Dict[str, Any]) -> str | None:
+    data = topic.get("snapshotData")
+    if isinstance(data, (bytes, bytearray, memoryview)):
+        encoded = base64.b64encode(bytes(data)).decode("ascii")
+        return f"data:image/png;base64,{encoded}"
+
+    snapshot = topic.get("snapshot")
+    if isinstance(snapshot, str) and snapshot.strip():
+        return snapshot.strip()
+    return None
+
+
+def _normalise_topics(raw_topics: list[Dict[str, Any]]) -> list[Dict[str, Any]]:
+    normalised: list[Dict[str, Any]] = []
+    for topic in raw_topics:
+        if not isinstance(topic, dict):
+            continue
+
+        comments: list[Dict[str, str]] = []
+        for comment in topic.get("comments", []):
+            if not isinstance(comment, dict):
+                continue
+            comment_entry: Dict[str, str] = {
+                "author": str(comment.get("author") or ""),
+                "date": str(
+                    comment.get("date") or comment.get("createdAt") or ""
+                ),
+                "text": str(comment.get("text") or comment.get("comment") or ""),
+            }
+            if comment.get("guid"):
+                comment_entry["guid"] = str(comment.get("guid"))
+            comments.append(comment_entry)
+
+        viewpoints: list[str] = []
+        for viewpoint in topic.get("viewpoints", []):
+            if isinstance(viewpoint, str) and viewpoint.strip():
+                viewpoints.append(viewpoint.strip())
+            elif isinstance(viewpoint, dict):
+                for key in ("viewpoint", "snapshot", "guid", "index"):
+                    value = viewpoint.get(key)
+                    if isinstance(value, str) and value.strip():
+                        viewpoints.append(value.strip())
+                        break
+
+        normalised.append(
+            {
+                "guid": str(topic.get("guid") or ""),
+                "title": str(topic.get("title") or ""),
+                "status": str(topic.get("status") or ""),
+                "priority": str(topic.get("priority") or ""),
+                "author": str(topic.get("author") or ""),
+                "createdAt": str(topic.get("createdAt") or ""),
+                "comments": comments,
+                "viewpoints": viewpoints,
+                "snapshot": _serialise_snapshot(topic),
+            }
+        )
+
+    return normalised
+
+
 @router.post("/inspect")
 async def inspect_bcf(file: UploadFile = File(...)) -> dict:
     if file is None:
         raise HTTPException(status_code=400, detail="Aucun fichier fourni.")
 
     temp_path = ""
+    project_meta: Dict[str, Any] = {}
+    response_topics: list[Dict[str, Any]] = []
     try:
         temp_path = await _save_upload_to_temp(file)
         project_meta, topics = reader.read_bcf(temp_path)
+        response_topics = _normalise_topics(topics)
+        if not response_topics:
+            raise HTTPException(
+                status_code=400,
+                detail="Aucune donnée d'issue n'a pu être extraite du fichier fourni.",
+            )
     except Exception as exc:  # pragma: no cover - defensive programming
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     finally:
         _cleanup_file(temp_path)
         await file.close()
 
-    return {"project": project_meta, "topics": topics}
+    return {"project": project_meta, "topics": response_topics}
 
 
 @router.post("/merge")

--- a/backend/app/bcf/writer.py
+++ b/backend/app/bcf/writer.py
@@ -101,7 +101,7 @@ def _build_comments(parent: ET.Element, comments: Iterable[Dict[str, object]]) -
         if guid:
             elem.set("Guid", guid)
 
-        created_at = _coerce_str(comment.get("createdAt"))
+        created_at = _coerce_str(comment.get("date") or comment.get("createdAt"))
         if created_at:
             date = ET.SubElement(elem, "Date")
             date.text = created_at
@@ -111,7 +111,7 @@ def _build_comments(parent: ET.Element, comments: Iterable[Dict[str, object]]) -
             author_elem = ET.SubElement(elem, "Author")
             author_elem.text = author
 
-        comment_text = _coerce_str(comment.get("comment"))
+        comment_text = _coerce_str(comment.get("text") or comment.get("comment"))
         if comment_text:
             text_elem = ET.SubElement(elem, "Comment")
             text_elem.text = comment_text
@@ -199,7 +199,11 @@ def write_bcf(out_path: str, project_meta: dict, topics: List[dict]) -> None:
 
             _build_comments(markup_root, topic.get("comments", []))
 
-            viewpoints_input = [vp for vp in topic.get("viewpoints", []) if isinstance(vp, dict)]
+            viewpoints_input = [
+                vp
+                for vp in topic.get("_viewpointDetails", [])
+                if isinstance(vp, dict)
+            ]
 
             topic_snapshot_bytes = _pick_first_bytes(
                 topic,

--- a/frontend/src/components/IssueDetailDrawer.tsx
+++ b/frontend/src/components/IssueDetailDrawer.tsx
@@ -132,24 +132,14 @@ export const IssueDetailDrawer = ({ issue, open, onOpenChange }: IssueDetailDraw
                 Viewpoints ({issue.viewpoints.length})
               </h3>
               <div className="space-y-2">
-                {issue.viewpoints.map((viewpoint) => (
-                  <div 
-                    key={viewpoint.guid}
+                {issue.viewpoints.map((viewpoint, index) => (
+                  <div
+                    key={`${issue.guid}-viewpoint-${index}`}
                     className="p-3 border rounded-lg bg-card hover:bg-muted/50 transition-colors"
                   >
-                    <div className="text-sm font-medium">
-                      {viewpoint.title || 'Untitled Viewpoint'}
+                    <div className="text-sm font-medium break-words">
+                      {viewpoint || 'Viewpoint'}
                     </div>
-                    <div className="text-xs text-muted-foreground mt-1">
-                      {viewpoint.guid}
-                    </div>
-                    {viewpoint.snapshotUrl && (
-                      <img 
-                        src={viewpoint.snapshotUrl} 
-                        alt={viewpoint.title || 'Viewpoint'} 
-                        className="mt-2 w-full rounded border"
-                      />
-                    )}
                   </div>
                 ))}
               </div>
@@ -165,9 +155,13 @@ export const IssueDetailDrawer = ({ issue, open, onOpenChange }: IssueDetailDraw
               Comments ({issue.comments.length})
             </h3>
             <div className="space-y-3">
-              {issue.comments.map((comment) => (
-                <div 
-                  key={comment.guid}
+              {issue.comments.map((comment, index) => {
+                const formattedDate = comment.date
+                  ? new Date(comment.date).toLocaleDateString()
+                  : '—';
+                return (
+                <div
+                  key={comment.guid ?? `${issue.guid}-comment-${index}`}
                   className="p-4 border rounded-lg bg-card space-y-2"
                 >
                   <div className="flex items-center justify-between">
@@ -177,12 +171,15 @@ export const IssueDetailDrawer = ({ issue, open, onOpenChange }: IssueDetailDraw
                     </div>
                     <div className="flex items-center gap-1 text-xs text-muted-foreground">
                       <Calendar className="w-3 h-3" />
-                      {new Date(comment.date).toLocaleDateString()}
+                      {formattedDate}
                     </div>
                   </div>
-                  <p className="text-sm text-muted-foreground">{comment.comment}</p>
+                  <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+                    {comment.text || 'No comment text provided.'}
+                  </p>
                 </div>
-              ))}
+                );
+              })}
             </div>
           </div>
         </div>

--- a/frontend/src/components/IssuesTable.tsx
+++ b/frontend/src/components/IssuesTable.tsx
@@ -164,8 +164,14 @@ export const IssuesTable = ({ issues, onIssueClick }: IssuesTableProps) => {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {filteredIssues.map((issue) => (
-              <TableRow 
+            {filteredIssues.map((issue) => {
+              const createdDate = issue.createdAt ? new Date(issue.createdAt) : null;
+              const createdLabel = createdDate && !Number.isNaN(createdDate.getTime())
+                ? createdDate.toLocaleDateString()
+                : '—';
+
+              return (
+                <TableRow
                 key={issue.guid}
                 className="cursor-pointer hover:bg-muted/50"
                 onClick={() => onIssueClick(issue)}
@@ -198,7 +204,7 @@ export const IssuesTable = ({ issues, onIssueClick }: IssuesTableProps) => {
                 <TableCell>
                   <div className="flex items-center gap-2 text-sm text-muted-foreground">
                     <Calendar className="w-4 h-4" />
-                    {new Date(issue.createdAt).toLocaleDateString()}
+                    {createdLabel}
                   </div>
                 </TableCell>
                 <TableCell className="text-right">
@@ -214,8 +220,9 @@ export const IssuesTable = ({ issues, onIssueClick }: IssuesTableProps) => {
                     View
                   </Button>
                 </TableCell>
-              </TableRow>
-            ))}
+                </TableRow>
+              );
+            })}
           </TableBody>
         </Table>
       </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,19 +1,86 @@
+const API_BASE_URL = import.meta.env?.VITE_API_BASE_URL ?? 'http://localhost:8000';
+
+function buildUrl(path: string) {
+  return `${API_BASE_URL.replace(/\/$/, '')}${path}`;
+}
+
+async function ensureSuccess(response: Response): Promise<Response> {
+  if (response.ok) {
+    return response;
+  }
+
+  let message = 'Une erreur inattendue est survenue.';
+  try {
+    const data = await response.json();
+    if (typeof data?.detail === 'string') {
+      message = data.detail;
+    }
+  } catch (error) {
+    // Ignore JSON parse errors and fall back to status text
+  }
+
+  if (response.statusText) {
+    message = message || response.statusText;
+  }
+
+  throw new Error(message || 'Requête échouée.');
+}
+
 export async function inspectBcf(file: File) {
   const formData = new FormData();
-  formData.append("file", file);
-  const res = await fetch("http://localhost:8000/bcf/inspect", {
-    method: "POST",
-    body: formData,
-  });
-  return res.json();
+  formData.append('file', file);
+
+  const response = await ensureSuccess(
+    await fetch(buildUrl('/bcf/inspect'), {
+      method: 'POST',
+      body: formData,
+    })
+  );
+
+  return response.json() as Promise<{
+    project: Record<string, unknown>;
+    topics: Array<{
+      guid: string;
+      title: string;
+      status: string;
+      priority: string;
+      author: string;
+      createdAt: string;
+      comments: Array<{ guid?: string; author: string; date: string; text: string }>;
+      viewpoints: string[];
+      snapshot: string | null;
+    }>;
+  }>;
 }
 
 export async function mergeBcfs(files: File[]) {
   const formData = new FormData();
-  files.forEach(f => formData.append("files", f));
-  const res = await fetch("http://localhost:8000/bcf/merge", {
-    method: "POST",
-    body: formData,
-  });
-  return res.blob(); // download merged bcfzip
+  files.forEach((file) => formData.append('files', file));
+
+  const response = await ensureSuccess(
+    await fetch(buildUrl('/bcf/merge'), {
+      method: 'POST',
+      body: formData,
+    })
+  );
+
+  const disposition = response.headers.get('Content-Disposition') ?? '';
+  let filename = 'merged.bcfzip';
+  const match = /filename\*=UTF-8''([^;]+)/i.exec(disposition)
+    || /filename="?([^";]+)"?/i.exec(disposition);
+  if (match && match[1]) {
+    try {
+      filename = decodeURIComponent(match[1]);
+    } catch (error) {
+      filename = match[1];
+    }
+  }
+
+  const blob = await response.blob();
+  return { blob, filename };
 }
+
+export const apiClient = {
+  inspectBcf,
+  mergeBcfs,
+};

--- a/frontend/src/pages/Issues.tsx
+++ b/frontend/src/pages/Issues.tsx
@@ -7,9 +7,8 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { apiClient } from '@/lib/api';
 import { toast } from 'sonner';
-import { 
-  ArrowLeft, 
-  Download, 
+import {
+  ArrowLeft,
   Loader2,
   Merge,
   FileCheck
@@ -52,19 +51,17 @@ export default function Issues() {
     setIsMerging(true);
     
     try {
-      // Use mock merge for demo (switch to real API when backend is ready)
-      const blob = await apiClient.mergeBCFsWithMock(files);
-      
-      // Create download link
+      const { blob, filename } = await apiClient.mergeBcfs(files);
+
       const url = window.URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;
-      link.download = `merged-${Date.now()}.bcfzip`;
+      link.download = filename || `merged-${Date.now()}.bcfzip`;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
       window.URL.revokeObjectURL(url);
-      
+
       toast.success('BCF files merged successfully', {
         description: 'Download started automatically',
       });

--- a/frontend/src/store/bcfStore.ts
+++ b/frontend/src/store/bcfStore.ts
@@ -1,17 +1,13 @@
 import { create } from 'zustand';
 
 export interface BCFComment {
-  guid: string;
-  comment: string;
+  guid?: string;
   author: string;
   date: string;
+  text: string;
 }
 
-export interface BCFViewpoint {
-  guid: string;
-  title?: string;
-  snapshotUrl?: string;
-}
+export type BCFViewpoint = string;
 
 export interface BCFIssue {
   guid: string;


### PR DESCRIPTION
## Summary
- normalize BCF inspect responses to include required fields and clear errors
- retain viewpoint metadata for merging while exposing string lists to the UI
- switch the frontend to real inspect/merge APIs with robust parsing and UI updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd4cbaf1248326bd794f4d7b609deb